### PR TITLE
Update Lambda for `/manifests` route.

### DIFF
--- a/lambdas/manifestList/index.js
+++ b/lambdas/manifestList/index.js
@@ -14,16 +14,5 @@ exports.handler = async function (event, context) {
   });
   const response = await client.send(command);
   
-  const items = response.Items.map( (item) => {
-    return unmarshall(item);
-  });
-
-  return {
-    headers: {
-      "content-type": "application/json",
-    },
-    statusCode: 200,
-    body: JSON.stringify(items),
-  };
+  return response.Items.map((item) => unmarshall(item));
 };
-


### PR DESCRIPTION
This should update the Lambda to do basic process on dynamoDb items list and then return that out. We no longer stringify or return the the status code.