### PR TITLE
Add update manifest functionality.

### DIFF
--- a/lambdas/writeManifest/index.js
+++ b/lambdas/writeManifest/index.js
@@ -2,6 +2,7 @@ const { DynamoDBDocumentClient, GetCommand } = require("@aws-sdk/lib-dynamodb");
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const axios = require("axios");
+const { convertPresentation2 } = require("@iiif/parser/presentation-2");
 
 const BUCKET = process.env.BUCKET;
 const BASE_URL = process.env.BASE_URL;
@@ -9,85 +10,98 @@ const MANIFEST_TABLE_NAME = process.env.MANIFEST_TABLE_NAME;
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
-
 exports.handler = async function (event, context) {
   try {
+    /**
+     * fetch IIIF manifest
+     */
     const res = await axios.get(event.uri.S);
-    const data = res.data;
-    
+    const data = res?.data;
+
+    /**
+     * upgrades manifest to IIIF Presentation 3.0 API
+     */
+    const manifestJson = convertPresentation2(data);
+
     /**
      * constuct unique key patterns
      */
     const key = event.publishKey.S;
     const id = `${BASE_URL}/${key}`;
-    
+
     /**
      * stitch together new Manifest
      */
-     const manifest = {
-       ...data,
-       id: `${id}.json`,
-       seeAlso: [
-         ...data?.seeAlso,
-         {
-           id: data.id,
-           type: "Manifest",
-           format: "application/json",
-           label: {
-             none: ['Originating IIIF Manifest']
-           }
-         }
-       ]
-     };
-     
+    const manifest = {
+      ...manifestJson,
+      id: `${id}.json`,
+      seeAlso: [
+        ...manifestJson?.seeAlso,
+        {
+          id: manifestJson.id,
+          type: "Manifest",
+          format: "application/json",
+          label: {
+            none: ["Originating IIIF Manifest"],
+          },
+        },
+      ],
+    };
+
     /**
      * walk through Canvases
      */
-    await Promise.all(manifest.items.map(async (item, index) => {
-      /**
-       * tidy ids and create new Canvas
-       */
-      const canvasId = `${id}/canvas/${index}`;
-      const canvas = {
-        ...item,
-        id: canvasId
-      };
-      
-      canvas.items[0].id = `${canvasId}/page`;
-      canvas.items[0].items[0].id = `${canvasId}/annotation/0`;
-      canvas.items[0].items[0].target = canvasId;
-      
-      /**
-       * annotate Canvas
-       */
-      const serviceId = item.items[0].items[0].body.service[0]["@id"];
-      const annotations = await getAnnotations(event.uri.S, serviceId, canvasId);
-      
-      if (annotations.length > 0) {
-        canvas.annotations = [{
-          "id": `${canvasId}/annotations`, 
-          "type": "AnnotationPage",
-          "items": annotations
-        }];
-      }
-      
-      manifest.items[index] = canvas;
-    }));
-    
+    await Promise.all(
+      manifest.items.map(async (item, index) => {
+        /**
+         * tidy ids and create new Canvas
+         */
+        const canvasId = `${id}/canvas/${index}`;
+        const canvas = {
+          ...item,
+          id: canvasId,
+        };
+
+        canvas.items[0].id = `${canvasId}/page`;
+        canvas.items[0].items[0].id = `${canvasId}/annotation/0`;
+        canvas.items[0].items[0].target = canvasId;
+
+        /**
+         * annotate Canvas
+         */
+        const serviceId = item.items[0].items[0].body.service[0]["@id"];
+        const annotations = await getAnnotations(
+          event.uri.S,
+          serviceId,
+          canvasId
+        );
+
+        if (annotations.length > 0) {
+          canvas.annotations = [
+            {
+              id: `${canvasId}/annotations`,
+              type: "AnnotationPage",
+              items: annotations,
+            },
+          ];
+        }
+
+        manifest.items[index] = canvas;
+      })
+    );
+
     await saveDocumentToS3(key, manifest);
-    
-  } catch(error) {
+  } catch (error) {
     console.error(JSON.stringify(error));
   }
 
   return {
     statusCode: 200,
-    body: JSON.stringify('TODO'),
+    body: JSON.stringify("TODO"),
   };
 };
 
 async function getAnnotations(uri, serviceId, canvasId) {
-  
   /**
    * note that "commenting" is the spec valid motivation value, however the newly formed
    * IIIF Annotations TSG is proposing "transcribing" and "translating" as valid options
@@ -97,55 +111,57 @@ async function getAnnotations(uri, serviceId, canvasId) {
     {
       language: "ar",
       motivation: "commenting",
-      sortKey: "TRANSCRIPTION"
+      sortKey: "TRANSCRIPTION",
     },
     {
       language: "en",
       motivation: "commenting",
-      sortKey: "TRANSLATION"
-    }
-  ]; 
-  
-  const annotations = await Promise.all(items.map(async (entry) => {
-    const command = new GetCommand({
-      TableName: MANIFEST_TABLE_NAME,
-      Key: {
-        uri: uri,
-        sortKey: `${entry.sortKey}#${serviceId}` 
-      },
-    });
-    
-    const data = await docClient.send(command);
-    
-    if (!data?.Item?.value) return;
-    
-    return await {
-      "id": `${canvasId}/annotations/${entry.sortKey.toLowerCase()}`,
-      "type": "Annotation",
-      "motivation": entry.motivation,
-      "body": {
-        "type": "TextualBody",
-        "language": entry.language,
-        "format": "text/plain",
-        "value": data.Item.value
-      },
-      "target": canvasId
-    };
-  }));
-  
-  return annotations.filter(annotation => annotation);
+      sortKey: "TRANSLATION",
+    },
+  ];
+
+  const annotations = await Promise.all(
+    items.map(async (entry) => {
+      const command = new GetCommand({
+        TableName: MANIFEST_TABLE_NAME,
+        Key: {
+          uri: uri,
+          sortKey: `${entry.sortKey}#${serviceId}`,
+        },
+      });
+
+      const data = await docClient.send(command);
+
+      if (!data?.Item?.value) return;
+
+      return await {
+        id: `${canvasId}/annotations/${entry.sortKey.toLowerCase()}`,
+        type: "Annotation",
+        motivation: entry.motivation,
+        body: {
+          type: "TextualBody",
+          language: entry.language,
+          format: "text/plain",
+          value: data.Item.value,
+        },
+        target: canvasId,
+      };
+    })
+  );
+
+  return annotations.filter((annotation) => annotation);
 }
 
-async function saveDocumentToS3(key, doc){
+async function saveDocumentToS3(key, doc) {
   const s3Client = new S3Client();
   const params = {
     Bucket: BUCKET,
     ContentType: "application/json",
-    ContentEncoding: 'base64',
+    ContentEncoding: "base64",
     Key: `${key}.json`,
     ACL: "private",
-    Body: JSON.stringify(doc, null, 4)
-  }
+    Body: JSON.stringify(doc, null, 4),
+  };
   const putObjectCommand = new PutObjectCommand(params);
   return await s3Client.send(putObjectCommand);
 }

--- a/lambdas/writeManifest/package-lock.json
+++ b/lambdas/writeManifest/package-lock.json
@@ -9,8 +9,49 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@iiif/parser": "^2.0.1",
         "axios": "^1.6.2"
       }
+    },
+    "node_modules/@iiif/parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-2.0.1.tgz",
+      "integrity": "sha512-RnHzBnYiI49I+cV9uxkhvUBqNSqj90pX+0hRRZgQ51EO0Sww7l1G44e6pg66PFxiDsIRXrkk34I63fYB9L1VrA==",
+      "dependencies": {
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^2.1.3",
+        "@iiif/presentation-3-normalized": "^0.9.7",
+        "@types/geojson": "^7946.0.10"
+      }
+    },
+    "node_modules/@iiif/presentation-2": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
+      "peerDependencies": {
+        "@iiif/presentation-3": "*"
+      }
+    },
+    "node_modules/@iiif/presentation-3": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-2.1.3.tgz",
+      "integrity": "sha512-0V9LL+UPGknn4vdEJuJnuK0BsOL93dmr4PrdXg9fSE9HUq/2P0jkp4yGJR13f7N9OpmcRsEQjqWqVceWHB8Bow==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10"
+      }
+    },
+    "node_modules/@iiif/presentation-3-normalized": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3-normalized/-/presentation-3-normalized-0.9.7.tgz",
+      "integrity": "sha512-Aqk0sYBFIH5W3wmVxW02tnAFbNzUU5oPygGQjvszB3PP2nSkFQ1skVjqJhQPPZTyi/de1qcJUrgSy0vp6s+c5A==",
+      "dependencies": {
+        "@iiif/presentation-3": "^2.0.5"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/lambdas/writeManifest/package.json
+++ b/lambdas/writeManifest/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@iiif/parser": "^2.0.1",
     "axios": "^1.6.2"
   }
 }


### PR DESCRIPTION
This adds a manifest `convertPresentation2()` function to the writeManifests lambda that will upgrade a v2 manifest to presentation 3. This may be necessary for handling UIUC manifests.

```jsx
/**
 * upgrades manifest to IIIF Presentation 3.0 API
 */
const manifestJson = convertPresentation2(data);  
```

Verify this works by:

- Making sure a presentation 2 manifest is added as an item
- Making the referenced presentation 2 manifest public
- Publishing collection
- Verifying item is written to the collection items
- Viewing the manifest and verifying it is Presentation 3 in the context http://iiif.io/api/presentation/3/context.json

Note, my prettier in VS Code added a lot of changes here that are formatting and not functionality changes.