### PR TITLE
Update annotation mime type to fit markdown.

### DIFF
--- a/lambdas/writeManifest/index.js
+++ b/lambdas/writeManifest/index.js
@@ -141,7 +141,7 @@ async function getAnnotations(uri, serviceId, canvasId) {
         body: {
           type: "TextualBody",
           language: entry.language,
-          format: "text/plain",
+          format: "text/markdown",
           value: data.Item.value,
         },
         target: canvasId,


### PR DESCRIPTION
This simply updates our mime type to fit Markdown content on Annotations in our IIIF Manifests.